### PR TITLE
feat(open-bank-api-connection): connect and create token context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "boilerplate",
+  "name": "monly",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/contexts/tokenContext.tsx
+++ b/src/contexts/tokenContext.tsx
@@ -1,0 +1,31 @@
+import React, {
+  useState,
+  createContext,
+  SetStateAction,
+  useContext
+} from 'react';
+
+type AuthContextProps = {
+  token: string;
+  setToken: React.Dispatch<SetStateAction<string>>;
+};
+
+type WithChildren = {
+  children: React.ReactNode;
+};
+
+const AuthContext = createContext({} as AuthContextProps);
+
+function TokenProvider({ children }: WithChildren) {
+  const [token, setToken] = useState('');
+
+  return (
+    <AuthContext.Provider value={{ token, setToken }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useToken = (): AuthContextProps => useContext(AuthContext);
+
+export default TokenProvider;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,13 +1,13 @@
+import TokenProvider from 'contexts/tokenContext';
 import { AppProps } from 'next/app';
 import Head from 'next/head';
 
 import GlobalStyles from 'styles/global';
-
 function App({ Component, pageProps }: AppProps) {
   return (
-    <>
+    <TokenProvider>
       <Head>
-        <title>Boilerplate</title>
+        <title>Monly</title>
         <link
           rel="shortcut icon"
           href="/img/icon-192.png"
@@ -20,7 +20,7 @@ function App({ Component, pageProps }: AppProps) {
       </Head>
       <GlobalStyles />
       <Component {...pageProps} />
-    </>
+    </TokenProvider>
   );
 }
 

--- a/src/pages/api/accessToken.ts
+++ b/src/pages/api/accessToken.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import axios from 'axios';
+import { authData } from 'utils/openBankingAuth';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const { data } = await axios.post(
+      'https://openapi.xpi.com.br/oauth2/v1/access-token/',
+      authData,
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'User-Agent': 'PostmanRuntime/7.26.8'
+        }
+      }
+    );
+    const token: string = data.access_token;
+
+    return res.status(201).json({ token });
+  } catch (error) {
+    return res.status(400).json({ message: error });
+  }
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,31 @@
 // import Main from 'components/Main';
 
+import { AxiosError, AxiosResponse } from 'axios';
+import { useCallback, useEffect } from 'react';
+import { useAxios } from 'utils/useAxios';
+import { useToken } from '../contexts/tokenContext';
+
 export default function Home() {
+  const [axiosGet] = useAxios('get');
+  const { setToken } = useToken();
+
+  const getToken = useCallback(async () => {
+    await axiosGet({
+      url: '/api/accessToken',
+      success: (res: AxiosResponse) => {
+        const { token } = res.data;
+        setToken(token);
+      },
+      error: (err: AxiosError) => {
+        console.log(err);
+      }
+    });
+  }, [axiosGet, setToken]);
+
+  useEffect(() => {
+    getToken();
+  }, [getToken]);
+
   return (
     <>
       {/* <Main /> */}

--- a/src/utils/openBankingAuth.ts
+++ b/src/utils/openBankingAuth.ts
@@ -1,0 +1,13 @@
+const grantType = process.env.GRANT_TYPE;
+const clientID = process.env.CLIENT_ID;
+const clientSecret = process.env.CLIENT_SECRET;
+
+const authData = new URLSearchParams();
+
+if (grantType && clientID && clientSecret) {
+  authData.append('grant_type', grantType);
+  authData.append('client_id', clientID);
+  authData.append('client_secret', clientSecret);
+}
+
+export { authData };

--- a/src/utils/useAxios.ts
+++ b/src/utils/useAxios.ts
@@ -1,0 +1,101 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/no-empty-function */
+import axios from 'axios';
+import { useCallback } from 'react';
+// import { Router } from '../routes';
+
+export interface HttpParams {
+  url: string;
+  body?: object;
+  setState?: Function;
+  process?: Function;
+  success?: Function;
+  error?: Function;
+  config?: object;
+}
+
+const api = axios.create();
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+function useAxios(...methods: ('get' | 'post' | 'put' | 'delete' | 'patch')[]) {
+  if (methods.length === 0) {
+    throw new TypeError(
+      'Methods array is empty, add a method to `useAxios` parameters'
+    );
+  }
+
+  const functions = methods.map((method) => {
+    if (!['get', 'post', 'put', 'delete', 'patch'].includes(method)) {
+      throw new TypeError(`Invalid method (${method})`);
+    }
+
+    const httpRequest = async ({
+      url: relativeUrl = '/',
+      body = {},
+      setState = () => {},
+      process = (data: any) => data,
+      success = () => {},
+      error = () => {},
+      config = {}
+    }: HttpParams) => {
+      try {
+        const { headers } = getOptions();
+
+        const methodsArguments = {
+          get: [{ headers, ...config }],
+          post: [body, { headers, ...config }],
+          put: [body, { headers, ...config }],
+          patch: [body, { headers, ...config }],
+          delete: [{ headers, data: body, ...config }]
+        };
+
+        const res = await api[method](relativeUrl, ...methodsArguments[method]);
+
+        if (method === 'get') {
+          if (setState) {
+            setState(await process(res.data.data));
+          } else {
+            process(res.data.data);
+          }
+        }
+
+        await success(res, body);
+        return res;
+      } catch (err) {
+        console.log(err?.response);
+        await error(err);
+
+        return err;
+      }
+    };
+
+    return httpRequest;
+  });
+
+  const first = useCallback(functions[0], []);
+  const second = useCallback(functions[1], []);
+  const third = useCallback(functions[2], []);
+  const fourth = useCallback(functions[3], []);
+  const fifth = useCallback(functions[4], []);
+
+  return [
+    ...(first ? [first] : []),
+    ...(second ? [second] : []),
+    ...(third ? [third] : []),
+    ...(fourth ? [fourth] : []),
+    ...(fifth ? [fifth] : [])
+  ];
+}
+
+const getOptions = () => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*'
+  };
+  return {
+    headers
+  };
+};
+
+export { useAxios };


### PR DESCRIPTION
## What I did

- Create API route for getting the access token from Open Banking API credentials
- Create Token auth context and set the token to it's value on the load of the home page (via requistion)

## How to test

1. Open the terminal and go to the folder of this project

1. Change your .env to this: 
```
MONGODB_URI=mongodb+srv://ednaldo:pereirakk@cluster0.j5tpa.mongodb.net/hacka-xp?retryWrites=true&w=majority

#### OPEN BANKING API CREDENTIALS #####
GRANT_TYPE=client_credentials
CLIENT_ID=6jEi3HVS3zQj0WMkawIcH4COBfWRwueXW3k5bRnZOP0PdlWy
CLIENT_SECRET=6l7QXjN6zpUrhaZEm239YuoRBqn9kajO5ADBApiBhLN4HM6pgzzXVyq3du29NeGA
```

1. In terminal:
   1. `git checkout develop`
   1. `git pull`
   1. `git checkout feature/open-banking-api-connection`
   1. `git pull origin feature/open-banking-api-connection`
   1. `yarn install`
   1. `code .`
   1. `yarn start`

1. Go to the pages/index.tsx file, and add a `console.log(token)` on line 17 to test if the requistion is actually getting the API token. 

1. If you want to test the context, you can add a useEffect to this page that depends on the token variable, that you can import on line 10, and console it to see if the change is made. But this is really optional and only if you want to.

1. In your browser go to http://localhost:3000, open the browser's console and check if the console.log is showing.

1. Read the changed files section on GitHub

1. Test the things that you think are worth testing, even the ones that are not in this description

&nbsp;
***
